### PR TITLE
Add minimum requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 The GraphQL Twig module allows you to inject data into Twig templates by simply adding
 a GraphQL query. No site building or pre-processing necessary.
 
+## Requirements
+
+* Drupal >= 8.6
+* PHP >= 7.0
+
 ## Simple example 
 
 The *"Powered by Drupal"* block only gives credit to Drupal, but what's a website

--- a/graphql_twig.info.yml
+++ b/graphql_twig.info.yml
@@ -5,3 +5,4 @@ package: GraphQL
 core: 8.x
 dependencies:
   - graphql
+  - drupal:system (>= 8.6)


### PR DESCRIPTION
This should help make it clear Drupal 8.4 and 8.5 are no longer supported after being dropped in #3, as more than one person has run into a problems trying to use the module on 8.5 (https://github.com/drupal-graphql/graphql-twig/issues/4).

Also state minimum PHP version, as this is stricter than Drupal 8.6's requirements. I assume 7.0 is the minimum by looking at the .travis.yml commit logs.