### PR TITLE
Add graphql_core as dependency

### DIFF
--- a/graphql_twig.info.yml
+++ b/graphql_twig.info.yml
@@ -5,4 +5,5 @@ package: GraphQL
 core: 8.x
 dependencies:
   - graphql
+  - graphql_core
   - drupal:system (>= 8.6)


### PR DESCRIPTION
`graphql_core` needs to be enabled to get the schema and perform queries. Adding it so it gets enabled automatically when this module is enabled.